### PR TITLE
Support protocol in `config.host` string

### DIFF
--- a/__tests__/utils/fetchOptions.test.ts
+++ b/__tests__/utils/fetchOptions.test.ts
@@ -1,0 +1,35 @@
+import { IFlureeConfig } from "src/interfaces/IFlureeConfig";
+import { getFlureeBaseUrlFromConfig } from "../../src/utils/fetchOptions";
+
+describe('getFlureeBaseUrlFromConfig', () => {
+  it('can be backwards compatible', () => {
+    const originalConfig: IFlureeConfig = {
+      host: "localhost",
+      port: 8090,
+      ledger: "test/ledger"
+    };
+    const result = getFlureeBaseUrlFromConfig(originalConfig);
+    expect(result).toEqual("http://localhost:8090/fluree");
+  });
+
+  it('can support protocol in host string', () => {
+    const originalConfig: IFlureeConfig = {
+      host: "https://localhost",
+      port: 8090,
+      ledger: "test/ledger"
+    };
+    const result = getFlureeBaseUrlFromConfig(originalConfig);
+    expect(result).toEqual("https://localhost:8090/fluree");
+  });
+
+  it('can infer https from port', () => {
+    const originalConfig: IFlureeConfig = {
+      host: "localhost",
+      port: 443,
+      ledger: "test/ledger"
+    };
+    const result = getFlureeBaseUrlFromConfig(originalConfig);
+    expect(result).toEqual("https://localhost:443/fluree");
+  });
+
+});

--- a/src/core/FlureeClient.ts
+++ b/src/core/FlureeClient.ts
@@ -15,6 +15,7 @@ import { QueryInstance } from './QueryInstance';
 import { TransactionInstance } from './TransactionInstance';
 import fetch from 'cross-fetch';
 import flureeCrypto from '@fluree/crypto';
+import { getFlureeBaseUrlFromConfig } from '../utils/fetchOptions';
 const { generateKeyPair, pubKeyFromPrivate, accountIdFromPublic, createJWS } =
   flureeCrypto;
 
@@ -236,12 +237,9 @@ export class FlureeClient {
     ledgerName?: string,
     transaction?: IFlureeCreateTransaction,
   ): Promise<void> {
-    const { host, port, signMessages, privateKey } = this.config;
-    let url = `http://${host}`;
-    if (port) {
-      url += `:${port}`;
-    }
-    url += '/fluree/create';
+    const { signMessages, privateKey } = this.config;
+
+    const url = getFlureeBaseUrlFromConfig(this.config) + '/create';
     let body: IFlureeTransaction = {
       ledger: ledgerName || this.config.ledger,
       insert: { message: 'success' },

--- a/src/utils/fetchOptions.ts
+++ b/src/utils/fetchOptions.ts
@@ -1,37 +1,48 @@
 import { IFlureeConfig } from '../interfaces/IFlureeConfig';
 
+export const getFlureeBaseUrlFromConfig = (config: IFlureeConfig) => {
+  const { host, port, isFlureeHosted } = config;
+
+  let url = "";
+  if (isFlureeHosted) {
+    url = `https://data.flur.ee`;
+  } else {
+    // if protocol is not included in `config.host`, infer it from the port
+    if (!host?.startsWith("http://") && !host?.startsWith("https://")) {
+      const protocol = port === 443 ? "https://" : "http://";
+      url = `${protocol}${host}`;
+    } else {
+      url = `${host}`;
+    }
+    if (port) {
+      url += `:${port}`;
+    }
+  }
+  return `${url}/fluree`;
+}
+
 export const generateFetchParams = (
   config: IFlureeConfig,
   endpoint: string,
   contentType: string = "application/json"
 ): [
-  string,
-  {
-    method: string;
-    headers: {
-      'Content-Type': string;
-      Authorization?: string;
-    };
-    body?: string;
-  }
-] => {
-  const { host, port, isFlureeHosted, apiKey } = config;
-  let url;
-  if (isFlureeHosted) {
-    url = `https://data.flur.ee`;
-  } else {
-    url = `http://${host}`;
-    if (port) {
-      url += `:${port}`;
+    string,
+    {
+      method: string;
+      headers: {
+        'Content-Type': string;
+        Authorization?: string;
+      };
+      body?: string;
     }
-  }
-  url += `/fluree/${endpoint}`;
+  ] => {
+  const url = getFlureeBaseUrlFromConfig(config) + `/${endpoint}`;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const headers: any = {
     'Content-Type': contentType,
   };
-  if (apiKey) {
-    headers['Authorization'] = `Bearer ${apiKey}`;
+  if (config.apiKey) {
+    headers['Authorization'] = `Bearer ${config.apiKey}`;
   }
   return [
     url,


### PR DESCRIPTION
Now checks host string for protocol (http or https) and does not add protocol if already present.